### PR TITLE
Support for ordering using unknown/invalid fields in collections

### DIFF
--- a/src/main/java/org/datanucleus/store/mongodb/query/QueryToMongoDBMapper.java
+++ b/src/main/java/org/datanucleus/store/mongodb/query/QueryToMongoDBMapper.java
@@ -270,6 +270,7 @@ public class QueryToMongoDBMapper extends AbstractExpressionEvaluator
             {
                 OrderExpression orderExpr = (OrderExpression)expr;
                 MongoFieldExpression orderMongoExpr = (MongoFieldExpression) orderExpr.getLeft().evaluate(this);
+                if(orderMongoExpr == null) continue;
                 String orderDir = orderExpr.getSortOrder();
                 int direction = ((orderDir == null || orderDir.equals("ascending")) ? 1 : -1);
                 orderingObject.put(orderMongoExpr.getPropertyName(), direction);
@@ -595,9 +596,7 @@ public class QueryToMongoDBMapper extends AbstractExpressionEvaluator
                 return fieldExpr;
             }
         }
-
-        // TODO Auto-generated method stub
-        return super.processPrimaryExpression(expr);
+        return null;
     }
 
     /*


### PR DESCRIPTION
As pointed out in issue #43 this modifications allow a "more gentle" treatment of invalid fields in mongo collections. This has been already tested with our servers; trying to query using invalid fields in filters and in ordering. Only invalid orders are being allowed; invalid filters won't produce changes in current datanuclues-mongodb behabiour (it throws an exception; the same that throws the current version).

When using an invalid field for ordering; if datanucleus logging settings allow it, the user will be notified that the expresion given is not a member of the colletion and the action (the ordering) cannot take place in the datastore (this log message was already there). Then it returns null to the compileOrdering method; which will test if the ordering is null: if so it just ignores it.

In resume: this modifications allow to run a query if a typo or wrong string is used for ordering a query and notify the user in debugging sessions that the given ordering is not valid.