### PR TITLE
Proposal of ability to fetch and update/save NESTED embedded collections (lists, sets etc)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <dn.core.version>5.2.0-m1</dn.core.version>
-        <mongodb.version>3.8.0</mongodb.version>
+        <mongodb.version>3.9.1</mongodb.version>
     </properties>
 
     <scm>

--- a/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
+++ b/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
@@ -17,15 +17,12 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.mongodb;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
-
+import com.mongodb.DB;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.MongoException;
+import com.mongodb.ServerAddress;
 import org.datanucleus.ExecutionContext;
 import org.datanucleus.PropertyNames;
 import org.datanucleus.exceptions.NucleusDataStoreException;
@@ -40,12 +37,13 @@ import org.datanucleus.util.Localiser;
 import org.datanucleus.util.NucleusLogger;
 import org.datanucleus.util.StringUtils;
 
-import com.mongodb.DB;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoCredential;
-import com.mongodb.MongoException;
-import com.mongodb.ServerAddress;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
 
 /**
  * Implementation of a ConnectionFactory for MongoDB.
@@ -62,16 +60,16 @@ public class ConnectionFactoryImpl extends AbstractConnectionFactory
     public static final String MONGODB_HEARTBEAT_CONNECT_TIMEOUT = "datanucleus.mongodb.heartbeatConnectTimeout";
     public static final String MONGODB_HEARTBEAT_FREQUENCY = "datanucleus.mongodb.heartbeatFrequency";
     public static final String MONGODB_HEARTBEAT_SOCKET_TIMEOUT = "datanucleus.mongodb.heartbeatSocketTimeout";
-    
+
     public static final String MONGODB_MAX_CONNECTION_IDLE_TIME = "datanucleus.mongodb.maxConnectionIdleTime";
     public static final String MONGODB_MAX_CONNECTION_LIFE_TIME = "datanucleus.mongodb.maxConnectionLifeTime";
     public static final String MONGODB_MAX_WAIT_TIME = "datanucleus.mongodb.maxWaitTime";
-    
+
     public static final String MONGODB_MIN_HEARTBEAT_FREQUENCY = "datanucleus.mongodb.minHeartbeatFrequency";
     public static final String MONGODB_MIN_CONNECTIONS_PER_HOST = "datanucleus.mongodb.minConnectionsPerHost";
-    
+
     public static final String MONGODB_SERVER_SELECTION_TIMEOUT = "datanucleus.mongodb.serverSelectionTimeout";
-    
+
     public static final String MONGODB_SOCKET_TIMEOUT = "datanucleus.mongodb.socketTimeout";
 
     public static final String MONGODB_SSL_ENABLED = "datanucleus.mongodb.sslEnabled";
@@ -79,6 +77,7 @@ public class ConnectionFactoryImpl extends AbstractConnectionFactory
 
     public static final String MONGODB_CONNECTIONS_PER_HOST = "datanucleus.mongodb.connectionsPerHost";
     public static final String MONGODB_THREAD_BLOCK_FOR_MULTIPLIER = "datanucleus.mongodb.threadsAllowedToBlockForConnectionMultiplier";
+    public static final String MONGODB_REPLICA_SET_NAME = "datanucleus.mongodb.replicaSetName";
 
     String dbName = "DataNucleus";
 
@@ -298,6 +297,10 @@ public class ConnectionFactoryImpl extends AbstractConnectionFactory
         if (storeManager.hasProperty(MONGODB_THREAD_BLOCK_FOR_MULTIPLIER))
         {
             mongoOptionsBuilder.threadsAllowedToBlockForConnectionMultiplier(storeManager.getIntProperty(MONGODB_THREAD_BLOCK_FOR_MULTIPLIER));
+        }
+
+        if (storeManager.hasProperty(MONGODB_REPLICA_SET_NAME)) {
+            mongoOptionsBuilder.requiredReplicaSetName(storeManager.getStringProperty(MONGODB_REPLICA_SET_NAME));
         }
 
         return mongoOptionsBuilder.build();


### PR DESCRIPTION
Changes:
- Proposal of ability to fetch and update/save NESTED embedded collections
- updated dependencies on com.mongodb* to v3.9.1
- also a new property name `datanucleus.mongodb.replicaSetName` to define the desired name of replica set
- also ability to fetch Map with key and value of simple types when name of a
key-field from a dbObject differs from "key" and name of a value-field from a dbObject differs from "value"

It is related to #49 that has been closed because of invalidity. 

===================================================================
**1 Proposal of ability to fetch and update/save NESTED embedded collections.** The issue is described in #49 

It has not being working at case when there is a class that maps/describes some nested/embedded object and it has such fields:
- _collection of persistable nested/embedded objects_  (supposed to be resolved by the PR)
- array of nested/embedded persistable objects
- map where key and/or value is a nested/embedded persistable object

Changed files: **_FetchEmbeddedFieldManager.java_**, **_StoreEmbeddedFieldManager.java_**

===================================================================
**2 Updated dependencies on com.mongodb to v3.9.1**
Changed files: **_pom.xml_**

===================================================================
**3 A new property name `datanucleus.mongodb.replicaSetName` to define the desired name of replica set**

It is necessary to define such connection URL to connect to the database and make it save changes:
`mongodb://id_or_hostName:27017/dataBase?replicaSet=rs01`.  

It seems that options are defined by properties listed at `org.datanucleus.store.mongodb.ConnectionFactoryImpl` (see `public static final String ` fields). I could not find a way how to define the name of the replicaSet. 

Use case demonstration:
```java
PersistenceUnitMetaData pumd = new PersistenceUnitMetaData(parameters);
//further actions ...
pumd.addProperty("datanucleus.mongodb.replicaSetName", "rs01");
//further actions...

PersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(pumd, null);
```
Changed files: **_ConnectionFactoryImpl.java_**

===================================================================
**4 Ability to fetch Map with key and value of simple types when name of a key-field from a dbObject differs from "key" and name of a value-field from a dbObject differs from "value"**

There is an issue. The way to reproduce: 
- Document
![image](https://user-images.githubusercontent.com/4927589/49944720-2b82b480-fefc-11e8-9ab5-d61b4e03468c.png)

- Mapping
```java
@PersistenceCapable //the highest level persistable object
public class IssueTemplateDb {

    public IssueTemplateDb() {
        super();
    }

    @PrimaryKey
    @Column(name = "Title") //just for simplicity
    private String title;

    @Column(name = "AffectedDepartments")
    @Value(column = "_id")
    @Key(column = "Title")
    private Map<String, String> affectedDepartments;


    public Map<String, String> getAffectedDepartments() {
        return affectedDepartments;
    }

    public void setAffectedDepartments(Map<String, String> affectedDepartments) {
        this.affectedDepartments = affectedDepartments;
    }

    public String getTitle() {
        return title;
    }

    public void setTitle(String title) {
        this.title = title;
    }
}
```

- Code
```java
       PersistenceUnitMetaData pumd = new PersistenceUnitMetaData("dynamic-unit", "RESOURCE_LOCAL", null);
        pumd.addClassName(AffectedDepartment.class.getName());
        pumd.addClassName(IssueTemplateDb.class.getName());
        pumd.addProperty(...);
        //further actions...

        PersistenceManagerFactory pmf = new JDOPersistenceManagerFactory(pumd, null);
        PersistenceManager pm = pmf.getPersistenceManager();

        JDOQLTypedQuery<IssueTemplateDb> tq1 = pm.newJDOQLTypedQuery(IssueTemplateDb.class);

        QIssueTemplateDb c = QIssueTemplateDb.candidate();

        tq1.filter(c.title.eq("фаыв"))
                .orderBy(c.title.asc());
        List<IssueTemplateDb> result = tq1.executeList();
        assertThat(result.size(), is(1));
        result.get(0).getAffectedDepartments();
        result.get(0).getTitle();
```

**The result is**
![image](https://user-images.githubusercontent.com/4927589/49945354-bdd78800-fefd-11e8-95f0-43935679e737.png)

**With proposed changes the result is:** 
![image](https://user-images.githubusercontent.com/4927589/49946704-9635ef00-ff00-11e8-92d1-5e907332f789.png)


The same works ok when such field is a member of the class that describes some nested/embadded entity. 
Changed files: **_MongoDBUtils.java_**


It has to be reviewed. Also I would be happy to contribute more. 

