### PR TITLE
Keeping the unmapped values of embadded/nested objects in a datastore on the updating

### DIFF
--- a/src/main/java/org/datanucleus/store/mongodb/fieldmanager/StoreEmbeddedFieldManager.java
+++ b/src/main/java/org/datanucleus/store/mongodb/fieldmanager/StoreEmbeddedFieldManager.java
@@ -123,7 +123,15 @@ public class StoreEmbeddedFieldManager extends StoreFieldManager
                 DBObject obj;
                 if (nested)
                 {
-                    obj = new BasicDBObject();
+                    DBObject nestedObject = (DBObject) dbObject.get(mapping.getColumn(0).getName());
+                    if (nestedObject == null)
+                    {
+                        obj = new BasicDBObject();
+                    }
+                    else
+                    {
+                        obj = nestedObject;
+                    }
                 }
                 else
                 {

--- a/src/main/java/org/datanucleus/store/mongodb/fieldmanager/StoreFieldManager.java
+++ b/src/main/java/org/datanucleus/store/mongodb/fieldmanager/StoreFieldManager.java
@@ -287,8 +287,16 @@ public class StoreFieldManager extends AbstractStoreFieldManager
                 DBObject embeddedObject = dbObject;
                 if (nested)
                 {
-                    // Nested, so create nested object that we will store the embedded object in
-                    embeddedObject = new BasicDBObject();
+                    DBObject nestedObject = (DBObject) embeddedObject.get(mapping.getColumn(0).getName());
+                    if (nestedObject == null)
+                    {   //creates nested object when current field has null-value
+                        embeddedObject = new BasicDBObject();
+                    }
+                    else
+                    {   //when current field has a value that differs from null
+                        //then the value is updated
+                        embeddedObject = nestedObject;
+                    }
                 }
 
                 if (embcmd.hasDiscriminatorStrategy())


### PR DESCRIPTION
Case:
- there is a lot embadded/nested objects in documents of a datastore.
- some fields/objects are mapped by persistable classess. Other fields/objects are not mapped

Hi there. We are facing some strange behaviour in situation breathy described above. 

There are some documents that have a lot of nested/embadded objects. We don't make persistable classes, that fully describe these documents, only parts that are needed (for purposes of the test automating). 

When it tries to update such documents then unmapped data (embadded/nested objects or their fields) disappears.

I think it needs to keep not mapped data in a datastore (on the updating)