### PR TITLE
Implement MongoClientUrl to handle parsing of values from Connection URL.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>datanucleus-mongodb</artifactId>
-	<version>6.0.0-m2-SNAPSHOT</version>
+    <version>6.0.0-m2-SNAPSHOT</version>
 
     <name>DataNucleus MongoDB plugin</name>
     <description>
@@ -18,7 +18,7 @@
 
     <properties>
         <dn.core.version>5.9</dn.core.version>
-        <mongodb.version>3.9.1</mongodb.version>
+        <mongodb.version>3.12.8</mongodb.version>
     </properties>
 
     <scm>

--- a/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
+++ b/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,11 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contributors:
-...
+    ...
 **********************************************************************/
 package org.datanucleus.store.mongodb;
 
-import com.mongodb.*;
+import com.mongodb.DB;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
 import org.datanucleus.ExecutionContext;
 import org.datanucleus.PropertyNames;
 import org.datanucleus.exceptions.NucleusException;

--- a/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
+++ b/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
@@ -1,20 +1,20 @@
 /**********************************************************************
- Copyright (c) 2011 Andy Jefferson and others. All rights reserved.
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Copyright (c) 2011 Andy Jefferson and others. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
- http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
- Contributors:
- ...
- **********************************************************************/
+Contributors:
+...
+**********************************************************************/
 package org.datanucleus.store.mongodb;
 
 import com.mongodb.*;
@@ -29,6 +29,7 @@ import org.datanucleus.store.connection.ManagedConnection;
 import org.datanucleus.store.connection.ManagedConnectionResourceListener;
 import org.datanucleus.util.Localiser;
 import org.datanucleus.util.NucleusLogger;
+import org.datanucleus.util.StringUtils;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
@@ -89,12 +90,26 @@ public class ConnectionFactoryImpl extends AbstractConnectionFactory
         }
 
         MongoClientURI mongoClientURI = new MongoClientURI(url);
-        mongo = new MongoClient(mongoClientURI); //TODO Change to MongoClients.create(dbConnectionString)
 
+        //Set database name provided in url.
         if(mongoClientURI.getDatabase() != null && !mongoClientURI.getDatabase().isEmpty())
         {
-            dbName = mongoClientURI.getDatabase(); //Set database name provided in url.
+            dbName = mongoClientURI.getDatabase();
         }
+
+        // Create the Mongo connection pool
+        if (NucleusLogger.CONNECTION.isDebugEnabled())
+        {
+            NucleusLogger.CONNECTION.debug(Localiser.msg("MongoDB.ServerConnect", dbName, mongoClientURI.getHosts().size(), StringUtils.collectionToString(mongoClientURI.getHosts())));
+        }
+
+        mongo = new MongoClient(mongoClientURI); //TODO Change to MongoClients.create(dbConnectionString)
+
+        if (NucleusLogger.CONNECTION.isDebugEnabled())
+        {
+            NucleusLogger.CONNECTION.debug("Created MongoClient object on resource " + getResourceName());
+        }
+
     }
 
     private MongoClientOptions getMongodbOptions(StoreManager storeManager)

--- a/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
+++ b/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
@@ -17,7 +17,12 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.mongodb;
 
-import com.mongodb.*;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.DB;
 import org.datanucleus.ExecutionContext;
 import org.datanucleus.PropertyNames;
 import org.datanucleus.exceptions.NucleusException;

--- a/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
+++ b/src/main/java/org/datanucleus/store/mongodb/ConnectionFactoryImpl.java
@@ -236,7 +236,7 @@ public class ConnectionFactoryImpl extends AbstractConnectionFactory
             if (conn == null)
             {
                 // Create new connection
-                conn = mongo.getDB(dbName); // TODO Change this to getDatabase(...), dependent on TODO (line 98).
+                conn = mongo.getDB(dbName); // TODO Change this to getDatabase(...)
                 if (NucleusLogger.CONNECTION.isDebugEnabled())
                 {
                     NucleusLogger.CONNECTION.debug(Localiser.msg("009011", this.toString(), getResourceName()));


### PR DESCRIPTION
**Issues**

1. Unable to connect to MongoDB Atlas (MongoServer 4.4) due to mongo java driver version and changes in the URL structure.
2. Current implementation has custom logic for extracting information from url connection string (shards, host, port, credentials, DBName, etc), 

**Solutions For Above**

1. Updated mongodb java driver from 3.9.1 to 3.12.8
2. Implemented MongoClientUrl to do this parsing for us and create MongoClient directly. This significantly reduces bloated code and maintenance.

**Important Notes**

- Due to issue and solution 2, the localhost is now a value that needs to be provided based on specification provided by mongodb on url structure (https://docs.mongodb.com/manual/reference/connection-string/).
- Might require update on DN MongoDB documents?

